### PR TITLE
Add hyperlink to the PyconAU YouTube Channel

### DIFF
--- a/data/Page/about.md
+++ b/data/Page/about.md
@@ -44,4 +44,4 @@ PyCon AU is held in two year blocks at the same city.
 - 2018, 2019: Sydney, NSW
 - 2020, 2021: Adelaide, SA
 
-Videos from previous years can be watched on the PyConAU YouTube channel.
+Videos from previous years can be watched on the [PyConAU YouTube channel](https://www.youtube.com/user/PyConAU).


### PR DESCRIPTION
Hello!

I was looking at the about page for 2020 and thought that it would be nice if the about page linked to the PyConAU Youtube channel when it mentions it :) so here is a pull request!

Cheers
Caitlin