### PR TITLE
Update pre-recorded time requirements

### DIFF
--- a/data/SpeakerPack/_template.md.j2
+++ b/data/SpeakerPack/_template.md.j2
@@ -78,7 +78,7 @@ Some additional support is available for your stream, however; the AV team will 
 {% endif %}
 {% elif type == 'pre-record' %}
 
-- Video length: **two minutes shorter** than the duration you selected&mdash;so either **13, 23 or 53 minutes**. It can run a little shorter but it **can not** run longer, even by a second.
+- Video length: A **maximum** of the duration you selected&mdash;so either **15, 25 or 55 minutes**. It can run a little shorter but it **can not** run longer, even by a second.
 - Resolution: {% if room == 'curlyboi' %}1080p (1920x1080){% else %}720p (1280x720){% endif %}
 {%- if day == 'main' %}
     - **Note**: If you don't know which stream you'll be in yet, note that the Curlyboi Theatre is 1080p, and the other streams are 720p.


### PR DESCRIPTION
(As breaks are now 10 mins, we don't need these cut short).