### PR TITLE
Add Infra sponsor to footer

### DIFF
--- a/frontend/index.scss
+++ b/frontend/index.scss
@@ -379,12 +379,12 @@ footer {
   color: #777;
   background-color: #eee;
   grid-template:
-    "auspice transitional signup"
-    "auspice transitional copyright";
-  grid-template-columns: 1fr 1fr max-content;
+    "auspice video infra signup"
+    "auspice video infra copyright";
+  grid-template-columns: 1fr 1fr 1fr max-content;
 
   @media only screen and (max-width: 959px) {
-    grid-template: "auspice" "transitional" "signup" "copyright";
+    grid-template: "auspice" "video" "infra" "signup" "copyright";
   }
 
   section {
@@ -392,8 +392,11 @@ footer {
     &.auspice {
       grid-area: auspice;
     }
-    &.transitional {
-      grid-area: transitional;
+    &.video {
+      grid-area: video;
+    }
+    &.infra {
+      grid-area: infra;
     }
     &.signup {
       grid-area: signup;

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -45,9 +45,13 @@
         <h1>PyCon AU is an event of</h1>
         <img src='{% asset "sponsor-logos/la.svg" %}' alt="Linux Australia" />
       </section>
-      <section class="sponsor transitional">
-        <h1>Supported by</h1>
+      <section class="sponsor video">
+        <h1>Video Sponsor</h1>
         <img src='{% asset "sponsor-logos/buildkite.svg" %}' alt="Buildkite" />
+      </section>
+      <section class="sponsor infra">
+        <h1>Infrastructure Sponsor</h1>
+        <img src='{% asset "sponsor-logos/microsoft.png" %}' alt="Microsoft" />
       </section>
       <section class="signup">
         <h1>Sign up for announcements</h1>

--- a/templates/sponsors.html
+++ b/templates/sponsors.html
@@ -54,7 +54,7 @@ main %}
     </tr>
     <tr>
       <td colspan="2">
-        <h1>Infra Sponsor</h1>
+        <h1>Infrastructure Sponsor</h1>
       </td>
     </tr>
     <tr>


### PR DESCRIPTION
requires @excitedleigh approval

Change lists all non-digital sponsors, reflecting higher tier sponsorship more accurately. 

flexgrid is fancy